### PR TITLE
Fix evil-surround's csw, csW, css & csp

### DIFF
--- a/evil-embrace.el
+++ b/evil-embrace.el
@@ -230,7 +230,8 @@
   (let (overlay)
     (cond
      ((and outer inner)
-      (evil-surround-delete char outer inner)
+      (unless (evil-surround-delete-char-noop-p char)
+        (evil-surround-delete char outer inner))
       (let ((key (read-char)))
         (if (member key evil-embrace-evil-surround-keys)
             (evil-surround-region (overlay-start outer)

--- a/evil-embrace.el
+++ b/evil-embrace.el
@@ -98,7 +98,7 @@
 ;;   The keys that are processed by `evil-surround' are saved in the
 ;;   variable `evil-embrace-evil-surround-keys'. The default value is:
 ;;   ,----
-;;   | (?\( ?\[ ?\{ ?\) ?\] ?\} ?\" ?\' ?< ?> ?b ?B ?t)
+;;   | (?\( ?\[ ?\{ ?\) ?\] ?\} ?\" ?\' ?< ?> ?b ?B ?t ?w ?W ?s ?p)
 ;;   `----
 
 ;;   Note that this variable is buffer-local. You should change it in the
@@ -143,7 +143,7 @@
 (defvar evil-embrace-show-help-p t
   "Whether to show the help or not.")
 
-(defvar evil-embrace-evil-surround-keys '(?\( ?\[ ?\{ ?\) ?\] ?\} ?\" ?\' ?< ?> ?b ?B ?t ?\C-\[)
+(defvar evil-embrace-evil-surround-keys '(?\( ?\[ ?\{ ?\) ?\] ?\} ?\" ?\' ?< ?> ?b ?B ?t ?\C-\[ ?w ?W ?s ?p)
   "Keys that should be processed by `evil-surround'")
 (make-variable-buffer-local 'evil-embrace-evil-surround-keys)
 


### PR DESCRIPTION
Some time in 2018 `csw`, `csW`, `css` and `csp` [were ported from vim over to evil-surround](https://github.com/emacs-evil/evil-surround/pull/148/files). This package's `evil-embrace-evil-surround-change` advice for `evil-surround-change` breaks this behavior, and this PR fixes `evil-embrace-evil-surround-change` so that they behave as expected.

[See evil-surround's tests](https://github.com/emacs-evil/evil-surround/pull/148/files#diff-d91b856e12d018bedd47d516f5cb0de37b31a428cca9075430c3f555c751c18aR42-R51) for examples of how this is intended to work.