### PR TITLE
Fix XML attributes not being preserved

### DIFF
--- a/evil-embrace.el
+++ b/evil-embrace.el
@@ -211,7 +211,8 @@
   (interactive "c")
   (cond
    ((and outer inner)
-    (delete-region (overlay-start outer) (overlay-start inner))
+    (setq evil-surround-last-deleted-left
+          (delete-and-extract-region (overlay-start outer) (overlay-start inner)))
     (delete-region (overlay-end inner) (overlay-end outer))
     (goto-char (overlay-start outer)))
    (t


### PR DESCRIPTION
  Fix attributes not being preserved after changing XML/HTML tags.

  This feature was added to `evil-surround` in https://github.com/emacs-evil/evil-surround/commit/68f7033322dcba3781dddb48465878e896a9f57b.

  It requires `evil-surround-last-deleted-left` being [set in `evil-surround-delete`](https://github.com/emacs-evil/evil-surround/blob/3bd73794ee5a760118042584ef74e2b6fb2a1e06/evil-surround.el#L256).

  As `evil-embrace` overrides `evil-surround-delete`, it should also set this variable.
